### PR TITLE
Allow the updated_datastore.data.state to be TEMPLATE

### DIFF
--- a/src/python/dart/web/api/datastore.py
+++ b/src/python/dart/web/api/datastore.py
@@ -64,8 +64,9 @@ def patch_datastore(datastore):
 def update_datastore(datastore, updated_datastore):
     if datastore.data.state == DatastoreState.TEMPLATE and updated_datastore.data.state != DatastoreState.TEMPLATE:
         return {'results': 'ERROR', 'error_message': 'TEMPLATE state cannot be changed'}, 400, None
-    if updated_datastore.data.state not in [DatastoreState.ACTIVE, DatastoreState.INACTIVE, DatastoreState.DONE]:
-        return {'results': 'ERROR', 'error_message': 'state must be ACTIVE, INACTIVE, or DONE'}, 400, None
+    if updated_datastore.data.state not in [DatastoreState.ACTIVE, DatastoreState.INACTIVE,
+                                            DatastoreState.DONE, DatastoreState.TEMPLATE]:
+        return {'results': 'ERROR', 'error_message': 'state must be ACTIVE, INACTIVE, DONE, or TEMPLATE'}, 400, None
 
     # only allow updating fields that are editable
     sanitized_datastore = datastore.copy()


### PR DESCRIPTION
Hi, I am Fengmin from Data Science team of RMN. 

We found that when we want to sync_datastore using the dartclient developed by Zach, it raised error message said updated_datastore.data.state cannot be 'TEMPLATE'. After discussed with Zach, we changed the code a little bit so that now updated_datastore.data.state can be 'TEMPLATE'
