### PR TITLE
enabling local dev build and .travis builds to continue with dummySam…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules
 *.orig
 *.iml
 *.egg-info/
+settings.json
+dart.yaml

--- a/src/python/dart/auth/AuthenticationAlgoFactory.py
+++ b/src/python/dart/auth/AuthenticationAlgoFactory.py
@@ -12,8 +12,7 @@ def basic_auth(auth_header, api_key_service, user_service):
     api_key_record = api_key_service.get_api_key(api_key_value, False)
     if not api_key_record:
         raise DartAuthenticationException(
-            'DART is unable to authenticate your request, api_key missing or not found. api_key=%s' % auth_data[
-                'Credential'])
+            'DART is unable to authenticate your request, api_key missing or not found. api_key=%s' % api_key_value)
 
     user_record = user_service.get_user_by_email(api_key_record.user_id, False)
     if not user_record:

--- a/src/python/dart/client/python/dart_client.py
+++ b/src/python/dart/client/python/dart_client.py
@@ -4,6 +4,7 @@ import time
 
 import jsonpatch
 import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from basicauth import encode
 
 from dart.model.action import Action, ActionState
@@ -24,6 +25,9 @@ config_path = os.environ['DART_CONFIG']
 config = configuration(config_path)
 auth_config = config['auth']
 
+# Disable 'InsecureRequestWarning: Unverified HTTPS request is being made...' warnings in local dev mode.
+if auth_config.get('use_auth') and (auth_config.get('dart_server') == 'https://localhost:5000'):
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 class Dart(object):
 

--- a/tools/vagrant/docker_files/templates/additional_steps.sh.template
+++ b/tools/vagrant/docker_files/templates/additional_steps.sh.template
@@ -25,9 +25,10 @@ echo "Step 3/6: creating all tables in local database"
 STOP=1; 
 while [ $STOP -gt 0 ]; do 
   sh -c 'docker-compose logs web | tail -10'
-  docker-compose exec web curl -XPOST "http://127.0.0.1:5000/admin/create_all"; 
-  STOP=$?; 
-  sleep 1; 
+  docker-compose exec web curl -k -XPOST "https://127.0.0.1:5000/admin/create_all";
+  STOP=$?;
+  echo "Waiting for web worker to complete. Trying again in 15 seconds ..." 
+  sleep 15; 
 done
 
 # launch worker containers

--- a/tools/vagrant/docker_files/templates/dart-local.yaml.template
+++ b/tools/vagrant/docker_files/templates/dart-local.yaml.template
@@ -247,17 +247,28 @@ logging:
         handlers: [console]
 
 auth:
-    use_auth: False
-    ssl_cert_path: ./ui/onelogin/cert.pem
-    ssl_key_path: ./ui/onelogin/key.pem
+    use_auth: True
     config_path: ./ui/onelogin
-    module_source: ../auth/saml_auth.py
-    module: saml_auth
-    class: SamlAuth
-    appid: 555555
+    module_source: ../auth/dummy_saml_auth.py
+    module: dummy_saml_auth
+    class: DummySamlAuth
+    appid: 578793000
     onelogin_server: https://rmn.onelogin.com
     private_key: ''
-    x509cert: MIIE
-    dart_server: http://localhost:5000
+    x509cert: XXX
+    dart_server: https://localhost:5000
+    ssl_cert_path: ./ui/onelogin/cert.pem
+    ssl_key_path: ./ui/onelogin/key.pem
     dart_client_key: be3f29dd-8a1e-4fba-b2c8-f9b250009bd8
     dart_client_secret: 0f01ba8f-2536-4e41-92d3-a86ae541404c
+    predefined_auth_services:
+      - decode_dart@rmn.com
+        b79b7691-81dd-4b75-ba3a-1cc2f4a5bbd5
+        c907390a-0bb7-4bb9-b26b-53f2f5312f07
+      - portico_dart@rmn.com
+        f4f0bff1-3479-45bc-82b2-69d65f71a749
+        6d32429b-7e22-468a-b538-95277a4f164e
+      - savor_dart@rmn.com
+        93d1fc14-13af-4b5f-9754-e862005047cf
+        810d49d2-8564-44a0-a35a-d13e4434549c
+


### PR DESCRIPTION
…l authenticator (up to now travis/local-build did not use auth at all).  We update dart-local template to include dummySaml auth, additional_Steps.sh script uses https now and dart_client ignores insecure https certificates in local dev mode (https://localhost:5000).