### PR TITLE
notify user when terminating emr datastore before starting

### DIFF
--- a/src/python/dart/engine/emr/actions/terminate_datastore.py
+++ b/src/python/dart/engine/emr/actions/terminate_datastore.py
@@ -1,4 +1,5 @@
 from dart.model.datastore import DatastoreState
+from dart.model.exception import DartUserError
 
 
 def terminate_datastore(emr_engine, datastore, action):
@@ -11,6 +12,11 @@ def terminate_datastore(emr_engine, datastore, action):
         emr_engine.dart.patch_action(action, progress=1)
         return
 
-    emr_engine.conn.terminate_jobflow(datastore.data.extra_data['cluster_id'])
+    extra_data = datastore.data.extra_data or {}
+    cluster_id = extra_data.get('cluster_id')
+    if not cluster_id:
+        raise DartUserError('Cannot terminate datastore before starting')
+
+    emr_engine.conn.terminate_jobflow(cluster_id)
     emr_engine.dart.patch_datastore(datastore, state=DatastoreState.DONE)
     emr_engine.dart.patch_action(action, progress=1)

--- a/src/python/dart/model/exception.py
+++ b/src/python/dart/model/exception.py
@@ -21,7 +21,12 @@ class DartActionException(Exception):
         self.data = data
         super(Exception, self).__init__(message)
 
+
 class DartAuthenticationException(Exception):
     def __init__(self, message, data=None):
         self.data = data
         super(Exception, self).__init__(message)
+
+
+class DartUserError(Exception):
+    pass


### PR DESCRIPTION
DartUserError is the initial effort to differentiate between user error and dev error. I intend to refactor existing actions at some point to raise this error whenever an error is likely to be a result of misusing Dart, and using this to improve error notifications.
