### PR TITLE
Template actions

### DIFF
--- a/src/python/dart/auth/rmn_required_roles_impl.py
+++ b/src/python/dart/auth/rmn_required_roles_impl.py
@@ -13,6 +13,8 @@ Note:  All permissions are tied to the datastore owner on which we operate.
 
     * No limit on creating datastores.
 """
+from collections import namedtuple
+
 import logging
 _logger = logging.getLogger(__name__)
 
@@ -62,13 +64,22 @@ action_roles - Array What action roles are required, implies and, (e.g. edit/run
                permission, such as Can_edit_BA do we need to check datastore owner.
 """
 
-def does_key_exist(kwargs, dart_type):
-    return kwargs.get(dart_type) and \
-           hasattr(kwargs.get(dart_type), 'data') and \
-           hasattr(kwargs[dart_type].data, 'datastore_id')
+def does_key_exist(kwargs, dart_type, id_type='datastore_id'):
+
+    does_type_exist = \
+        kwargs.get(dart_type) and \
+        hasattr(kwargs.get(dart_type), 'data') and \
+        hasattr(kwargs.get(dart_type).data, id_type)
+
+    does_datastore_exist = True
+    if does_type_exist and (id_type == 'datastore_id'):
+        # This is to make sure that if we do have a datastore_id (id_type) it should be Truthy (not empty).
+        does_datastore_exist = bool(kwargs.get(dart_type).data.datastore_id)
+
+    return does_type_exist and does_datastore_exist
 
 # Retrieve all its Is_Member_Of roles.
-def get_datastore_owner_membership_roles(user, user_roles_service, get_known_entity, kwargs):
+def get_datastore_owner_membership_roles(user, user_roles_service, get_known_entity, kwargs, dart_client_name):
     _logger.info("Authorization: kwargs={0}".format(kwargs))
 
     # Not authorizing post for DATASTORE (create datastore)
@@ -78,23 +89,31 @@ def get_datastore_owner_membership_roles(user, user_roles_service, get_known_ent
         datastore_data = kwargs.get("datastore").data
 
     elif does_key_exist(kwargs=kwargs, dart_type="workflow"):
-        tmp_ds = get_known_entity("datastore", kwargs["workflow"].data.datastore_id)
+        tmp_ds = get_known_entity("datastore", kwargs.get("workflow").data.datastore_id)
         if tmp_ds and tmp_ds.data:
             datastore_data = tmp_ds.data
 
     elif does_key_exist(kwargs=kwargs, dart_type="workflow_instance"):
-        tmp_ds = get_known_entity("datastore", kwargs["workflow_instance"].data.datastore_id)
+        tmp_ds = get_known_entity("datastore", kwargs.get("workflow_instance").data.datastore_id)
         if tmp_ds and tmp_ds.data:
             datastore_data = tmp_ds.data
 
     elif does_key_exist(kwargs=kwargs, dart_type="action"):
-        tmp_ds = get_known_entity("datastore", kwargs["action"].data.datastore_id)
+        tmp_ds = get_known_entity("datastore", kwargs.get("action").data.datastore_id)
         if tmp_ds and tmp_ds.data:
             datastore_data = tmp_ds.data
 
+    # In case of a Template Action there will be no datastore_id to use.
+    # So we will use the action's user_id as a substitute to datastore's user_id.
+    elif does_key_exist(kwargs=kwargs, dart_type='action', id_type='user_id'):
+        _logger.info("Authorization: Template Action has no datastore user. Using action's user {action_user} instead.".\
+                       format(action_user=kwargs.get("action").data.user_id))
+        FakeDatastoreData = namedtuple('FakeDatastoreData', 'user_id')
+        datastore_data = FakeDatastoreData(user_id=kwargs.get("action").data.user_id)
+
     datastore_user_id = datastore_data.user_id if hasattr(datastore_data, "user_id") else None
     actions, memberships, is_member_all = get_current_user_permssions(datastore_user_id, user_roles_service)
-    if is_member_all and user != DART_CLIENT_NAME:
+    if is_member_all and user != dart_client_name:
         # datastore_data.user_id = current_user.email
         # TODO: Should we overwrite the user by whoever runs it?
         pass
@@ -236,7 +255,8 @@ def prepare_inputs(current_user, kwargs, user_roles_service, get_known_entity, d
                 get_datastore_owner_membership_roles(user=user,
                                                      user_roles_service=user_roles_service,
                                                      get_known_entity=get_known_entity,
-                                                     kwargs=kwargs)
+                                                     kwargs=kwargs,
+                                                     dart_client_name=dart_client_name)
             inputs['datastore_user_id_'] = datastore_user_id
             inputs['ds_memberships_'] = ds_memberships
             inputs['is_ds_member_all_'] = is_member_all

--- a/src/python/dart/web/api/entity_lookup.py
+++ b/src/python/dart/web/api/entity_lookup.py
@@ -42,6 +42,7 @@ def get_known_entity(entity_name, entity_id):
     if model:
         return model
 
+    _logger.warn("Entity not found! {entity} with id {id}".format(entity=entity_name, id=entity_id))
     return None
 
 def fetch_model(f):

--- a/tests/python/dart/auth/rmn_required_roles_test.py
+++ b/tests/python/dart/auth/rmn_required_roles_test.py
@@ -1,10 +1,43 @@
 # must run pip install -e . in src/python folder before running this unit test
 import unittest
+from collections import namedtuple
 
-from dart.auth.rmn_required_roles_impl import prepare_inputs, authorization_decorator
+from dart.auth.rmn_required_roles_impl import prepare_inputs, authorization_decorator, does_key_exist
 
 
 class InputTests(unittest.TestCase):
+
+    # This function creates a fake user_role_Service object. It returns values (action_list and membership_list) only
+    # for the recognized_user, otherwise it throws and error.
+    # e.g action_list=['Can_edit'], membership_list=['Is_member_Of_BA']
+    def create_fake_user_role_service(self, recognized_user, action_list, membership_list):
+        def get_user_roles_func(usr):
+            if usr == recognized_user:
+                return action_list, membership_list
+
+            raise ValueError("wrong user")
+
+        FakeUserRoles = namedtuple('FakeUserRoles', 'get_user_roles')
+        return FakeUserRoles(get_user_roles=get_user_roles_func)
+
+    def create_fake_kwargs(self, data=None, type='action'):
+        def get_func(action_type):
+            if (type == action_type):
+                FakeData = namedtuple('FakeData', 'data')
+                return FakeData(data=data)
+
+            return None
+
+        FakeKwargs = namedtuple('FakeKwargs', 'get')
+        return FakeKwargs(get=get_func)
+
+    def create_fake_get_known_entity(self, data=None):
+        def get_known_entity_func(entity_name, id):
+            FakeKnownEntity = namedtuple('FakeKnownEntity', 'data')
+            return FakeKnownEntity(data=data)
+
+        #get_known_entity,  data.datastore_id
+        return get_known_entity_func
 
     class User(object):
         email = ""
@@ -16,13 +49,13 @@ class InputTests(unittest.TestCase):
 
     def setUp(self):
         user = self.User('dart@rmn.com')
-        self.inputs = { 'current_user': user,
-                        'kwargs': None,
-                        'user_roles_service': None,
-                        'get_known_entity': None,
-                        'debug_uuid': 'DBG',
-                        'action_roles': ['Edit'],
-                        'dart_client_name': None
+        self.inputs = {'current_user': user,
+                       'kwargs': None,
+                       'user_roles_service': None,
+                       'get_known_entity': None,
+                       'debug_uuid': 'DBG',
+                       'action_roles': ['Edit'],
+                       'dart_client_name': None
                        }
 
     def test_no_user(self):
@@ -35,14 +68,86 @@ class InputTests(unittest.TestCase):
         self.assertEqual(prepare_inputs(**self.inputs),
                          "Authorization: dart@rmn.com-DBG  Missing action_roles, not in ActionRoles ['Create', 'Edit', 'Run', 'Delete']. user=dart@rmn.com, action_roles=['typo']")
 
-
     def test_using_super_user(self):
         self.inputs['dart_client_name'] = self.inputs['current_user'].email
         ret = prepare_inputs(**self.inputs)
         self.assertTrue(isinstance(ret, dict))
 
-#################################
+    def test_using_user_with_Admin_membership(self):
+        self.inputs['dart_client_name'] = 'whatever@rmn.com'
+        self.inputs['user_roles_service'] = self.create_fake_user_role_service(self.inputs['current_user'].email,
+                                                                               ['Can_Edit'],
+                                                                               ['Is_Member_Of_BA', 'Is_Member_Of_Admin'])
+        ret = prepare_inputs(**self.inputs)
+        self.assertTrue(isinstance(ret, dict))
 
+    def test_using_non_existing_user(self):
+        self.inputs['dart_client_name'] = 'whatever@rmn.com'
+        self.inputs['user_roles_service'] = self.create_fake_user_role_service("missing_user@rmn.com",
+                                                                               ['Can_Edit'],
+                                                                               ['Is_Member_Of_BA'])
+        ret = prepare_inputs(**self.inputs)
+        self.assertEqual(ret, "Authorization: dart@rmn.com-DBG  Current user's dart@rmn.com is likely not in database.")
+
+    def test_using_user_with__non_Admin_membership(self):
+        self.inputs['dart_client_name'] = 'whatever@rmn.com'
+        self.inputs['user_roles_service'] = self.create_fake_user_role_service(self.inputs['current_user'].email,
+                                                                               ['Can_Edit'],
+                                                                               ['Is_Member_Of_BA'])
+        FakeDatastoreId = namedtuple('FakeDatastoreId', 'datastore_id')
+        fakeDatastoreId = FakeDatastoreId(datastore_id=self.inputs['current_user'].email)
+        self.inputs['kwargs'] = self.create_fake_kwargs(data=fakeDatastoreId, type='workflow')
+
+        FakeUserId = namedtuple('FakeDatastoreId', 'user_id')
+        fakeUserId = FakeUserId(user_id=self.inputs['current_user'].email)
+        self.inputs['get_known_entity'] = self.create_fake_get_known_entity(data=fakeUserId)
+
+        ret = prepare_inputs(**self.inputs)
+        self.assertTrue(isinstance(ret, dict))
+
+    def test_using_non_existing_user(self):
+        self.inputs['dart_client_name'] = 'whatever@rmn.com'
+        self.inputs['user_roles_service'] = self.create_fake_user_role_service("missing_user@rmn.com",
+                                                                               ['Can_Edit'],
+                                                                               ['Is_Member_Of_BA'])
+        ret = prepare_inputs(**self.inputs)
+        self.assertEqual(ret, "Authorization: dart@rmn.com-DBG  Current user's dart@rmn.com is likely not in database.")
+
+    def test_template_action_with_no_datastore_id(self):
+        self.inputs['dart_client_name'] = 'whatever@rmn.com'
+        self.inputs['user_roles_service'] = self.create_fake_user_role_service(self.inputs['current_user'].email,
+                                                                               ['Can_Edit'],
+                                                                               ['Is_Member_Of_BA'])
+
+        FakeUserIdWithEmptyDatastoreId = namedtuple('FakeUserIdWithEmptyDatastoreId', ['user_id', 'datastore_id'])
+        fakeUserIdWithEmptyDatastoreId = FakeUserIdWithEmptyDatastoreId(user_id=self.inputs['current_user'].email,
+                                                                        datastore_id=u'')
+
+        self.inputs['kwargs'] = self.create_fake_kwargs(data=fakeUserIdWithEmptyDatastoreId, type='action')
+        self.inputs['get_known_entity'] = self.create_fake_get_known_entity(data=fakeUserIdWithEmptyDatastoreId)
+
+        ret = prepare_inputs(**self.inputs)
+        self.assertTrue(isinstance(ret, dict))
+
+    def test_empty_datastoreid_key_does_not_exist(self):
+        FakeUserIdWithEmptyDatastoreId = namedtuple('FakeUserIdWithEmptyDatastoreId', ['user_id', 'datastore_id'])
+        fakeUserIdWithEmptyDatastoreId = FakeUserIdWithEmptyDatastoreId(user_id='whatever@rmn.com', datastore_id=u'')
+        kwargs_empty_datastore_id = self.create_fake_kwargs(data=fakeUserIdWithEmptyDatastoreId, type='action')
+
+        self.assertFalse(does_key_exist(kwargs=kwargs_empty_datastore_id ,dart_type='action', id_type='datastore_id'))
+        self.assertTrue(does_key_exist(kwargs=kwargs_empty_datastore_id ,dart_type='action', id_type='user_id'))
+
+    def test_real_datastoreid_key_exist(self):
+        FakeUserIdWithRealDatastoreId = namedtuple('FakeUserIdWithRealDatastoreId', ['user_id', 'datastore_id'])
+        fakeUserIdWithRealDatastoreId = FakeUserIdWithRealDatastoreId(user_id='whatever@rmn.com', datastore_id=u'real!')
+        kwargs_real_datastore_id = self.create_fake_kwargs(data=fakeUserIdWithRealDatastoreId, type='action')
+
+        self.assertTrue(does_key_exist(kwargs=kwargs_real_datastore_id ,dart_type='action', id_type='datastore_id'))
+        self.assertTrue(does_key_exist(kwargs=kwargs_real_datastore_id ,dart_type='action', id_type='user_id'))
+
+
+
+#################################
 class DecoratorTests(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Added unit tests fixed typos that came up during unit test running.
Specifically, checking whether an action is a template action (has no datastore_id).  In this case in order to proceed with the authorization we use the user_id of the action as the owner for authorization purposes.