### PR TITLE
add the ability for the user to define the ec2 key-pair name for emr …

### DIFF
--- a/src/python/dart/engine/emr/actions/start_datastore.py
+++ b/src/python/dart/engine/emr/actions/start_datastore.py
@@ -72,7 +72,7 @@ def start_datastore(emr_engine, datastore, action):
 
 def create_cluster(bootstrap_actions_args, cluster_name, datastore, emr_engine, instance_groups_args,
                    steps=None, auto_terminate=False, configuration_overrides=None):
-    keyname = emr_engine.ec2_keyname
+    keyname = datastore.data.args['ec2_keyname'] if datastore.data.args.get('ec2_keyname') else emr_engine.ec2_keyname
     instance_profile = emr_engine.instance_profile
     subnet_id = emr_engine.subnet_id
     cmd = 'aws emr create-cluster' \

--- a/src/python/dart/engine/emr/add_engine.py
+++ b/src/python/dart/engine/emr/add_engine.py
@@ -63,6 +63,7 @@ def add_emr_engine(config):
                 'instance_count': {'type': ['integer', 'null'], 'default': None, 'minimum': 1, 'maximum': 50, 'description': 'The total number of nodes in this cluster (overrides data_to_freespace_ratio)'},
                 'data_to_freespace_ratio': {'type': ['number', 'null'], 'default': 0.5, 'minimum': 0.0, 'maximum': 1.0, 'description': 'Desired ratio of HDFS data/free-space'},
                 'dry_run': {'type': ['boolean', 'null'], 'default': False, 'description': 'write extra_data to actions, but do not actually run'},
+                'ec2_keyname': {'type': 'string', 'description': 'The name of the ec2_key_pair for the emr cluster. If this is not defined, the default key-pair from config is chosen.', 'default': None},
             },
             'additionalProperties': False,
             'required': ['release_label'],

--- a/src/python/dart/engine/emr/test/test_start_datastore.py
+++ b/src/python/dart/engine/emr/test/test_start_datastore.py
@@ -93,7 +93,7 @@ class TestStartDatastoreAction(unittest.TestCase):
                 'Function': 'a-b',
                 'Accounting': '222-1111111'
             },
-            cluster_availability_zone='regionb',
+            subnet_id='subnetid12345',
             dart_host='somehost',
             dart_port=5000
         )


### PR DESCRIPTION
…cluster #109

check for key error on dictionary when retrieving ec2_keyname #109

fix emr test_start_datastore.py #109