### PR TITLE
Support more interesting data_check scenarios by allowing users to define expected count and operators.

### DIFF
--- a/src/python/dart/engine/elasticsearch/actions/data_check.py
+++ b/src/python/dart/engine/elasticsearch/actions/data_check.py
@@ -1,11 +1,21 @@
 import logging
 import json
 import traceback
+import operator
 
 from dart.engine.elasticsearch.admin.cluster import ElasticsearchCluster
 
 _logger = logging.getLogger(__name__)
 
+
+OPS = {
+    '<=': operator.le,
+    '<': operator.lt,
+    '>=': operator.ge,
+    '>': operator.ge,
+    '==': operator.eq,
+    '!=': operator.ne
+}
 
 def data_check(elasticsearch_engine, datastore, action):
     """
@@ -22,6 +32,10 @@ def data_check(elasticsearch_engine, datastore, action):
         # ensure json is well-formed
         query_body = json.dumps(json.loads(action.data.args['query_body']))
 
+        op = OPS[action.data.args['operator']]
+
+        expected_count = action.data.args['expected_count']
+
         valid = es.indices.validate_query(index=action.data.args['index'],
                                           doc_type=action.data.args['document_type'],
                                           body=query_body).get('valid')
@@ -29,11 +43,11 @@ def data_check(elasticsearch_engine, datastore, action):
         if not valid:
             raise Exception('Elasticsearch data check query is invalid.')
 
-        response = es.search(index=action.data.args['index'],
-                             doc_type=action.data.args['document_type'],
-                             body=query_body)
+        response = es.count(index=action.data.args['index'],
+                            doc_type=action.data.args['document_type'],
+                            body=query_body)
 
-        if response['hits']['total'] > 0:
+        if op(response['count'], expected_count):
             elasticsearch_engine.dart.patch_action(action, progress=1)
         else:
             raise Exception('Elasticsearch data check failed.')

--- a/src/python/dart/engine/elasticsearch/actions/data_check.py
+++ b/src/python/dart/engine/elasticsearch/actions/data_check.py
@@ -50,7 +50,10 @@ def data_check(elasticsearch_engine, datastore, action):
         if op(response['count'], expected_count):
             elasticsearch_engine.dart.patch_action(action, progress=1)
         else:
-            raise Exception('Elasticsearch data check failed.')
+            raise Exception('Elasticsearch data_check[name=%s] failed. Expected: %d %s %d' % (action.data.name,
+                                                                                              response['count'],
+                                                                                              action.data.args['operator'],
+                                                                                              expected_count))
     except Exception as e:
         error_message = e.message + '\n\n\n' + traceback.format_exc()
         raise Exception('Elasticsearch data check failed to execute: %s' % error_message)

--- a/src/python/dart/engine/elasticsearch/elasticsearch.py
+++ b/src/python/dart/engine/elasticsearch/elasticsearch.py
@@ -9,7 +9,6 @@ from dart.engine.elasticsearch.actions.create_template import create_template
 from dart.engine.elasticsearch.actions.create_mapping import create_mapping
 from dart.engine.elasticsearch.actions.delete_index import delete_index
 from dart.engine.elasticsearch.actions.delete_template import delete_template
-from dart.engine.elasticsearch.actions.delete_mapping import delete_mapping
 from dart.engine.elasticsearch.actions.force_merge_index import force_merge_index
 from dart.engine.elasticsearch.metadata import ElasticsearchActionTypes
 from dart.model.engine import ActionResultState, ActionResult

--- a/src/python/dart/engine/elasticsearch/metadata.py
+++ b/src/python/dart/engine/elasticsearch/metadata.py
@@ -31,6 +31,26 @@ class ElasticsearchActionTypes(object):
                                    + '("hits" in Elasticsearch terminology") for the data check to pass. '
                                    + 'https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-dsl.html'
                 },
+                'expected_count': {
+                    'type': 'integer',
+                    'default': 0,
+                    'description': 'The expected count to of documents to be returned by the query. '
+                                   + ' Use this and the operator to return a truthy value for the data check to pass.'
+                },
+                'operator': {
+                    'type': 'string',
+                    'default': '>',
+                    'description': 'The operator to apply to the query and expected count. '
+                                  + 'i.e. result count > expected count ',
+                    'enum': [
+                        '>',
+                        '>=',
+                        '<',
+                        '<=',
+                        '==',
+                        '!='
+                    ]
+                }
             },
             'additionalProperties': False,
             'required': ['query_body'],


### PR DESCRIPTION
By allowing users to specify the expected count and the operator to compare with the data_check action allows for more interesting scenarios.

Also moved the call to hit the ES _count api since we do not care about results and only concerned with the number of documents that match the query.