### PR TITLE
DW-6260: Adding HALT state to Action onFailure responses.  This state…

### DIFF
--- a/src/python/dart/message/trigger_listener.py
+++ b/src/python/dart/message/trigger_listener.py
@@ -124,7 +124,7 @@ class TriggerListener(object):
             if state == ActionState.FAILED:
                 callbacks.append(lambda: self._emailer.send_action_failed_email(action, datastore))
 
-                if action.data.on_failure == ActionOnFailure.DEACTIVATE:
+                if action.data.on_failure in [ActionOnFailure.DEACTIVATE, ActionOnFailure.HALT]:
                     try_next_action = False
                     if wf and wfi:
                         self._workflow_service.update_workflow_instance_state(wfi, WorkflowInstanceState.FAILED)
@@ -132,9 +132,11 @@ class TriggerListener(object):
                             retry_num = wfi.data.retry_num + 1
                             callbacks.append(lambda: self._trigger_proxy.trigger_workflow_retry(wfid, retry_num))
                         else:
-                            self._workflow_service.update_workflow_state(wf, WorkflowState.INACTIVE)
-                            if wf.data.on_failure == WorkflowOnFailure.DEACTIVATE:
-                                self._datastore_service.update_datastore_state(datastore, DatastoreState.INACTIVE)
+                            # if we halt we should not mark the workflow as inactive.
+                            if action.data.on_failure == ActionOnFailure.DEACTIVATE:
+                                self._workflow_service.update_workflow_state(wf, WorkflowState.INACTIVE)
+                                if wf.data.on_failure == WorkflowOnFailure.DEACTIVATE:
+                                    self._datastore_service.update_datastore_state(datastore, DatastoreState.INACTIVE)
                         f1 = Filter('workflow_instance_id', Operator.EQ, wfiid)
                         f2 = Filter('state', Operator.EQ, ActionState.HAS_NEVER_RUN)
                         for a in self._action_service.query_actions_all(filters=[f1, f2]):

--- a/src/python/dart/model/action.py
+++ b/src/python/dart/model/action.py
@@ -51,17 +51,18 @@ class ActionState(object):
 
 class OnFailure(object):
     DEACTIVATE = 'DEACTIVATE'
+    HALT = 'HALT'
     CONTINUE = 'CONTINUE'
 
     @staticmethod
     def all():
-        return [OnFailure.DEACTIVATE, OnFailure.CONTINUE]
+        return [OnFailure.DEACTIVATE, OnFailure.HALT, OnFailure.CONTINUE]
 
 
 @dictable
 class ActionData(BaseModel):
     def __init__(self, name, action_type_name, args=None, state=ActionState.HAS_NEVER_RUN, queued_time=None, start_time=None,
-                 end_time=None, progress=None, order_idx=None, error_message=None, on_failure=OnFailure.DEACTIVATE,
+                 end_time=None, progress=None, order_idx=None, error_message=None, on_failure=OnFailure.HALT,
                  on_failure_email=None, on_success_email=None, engine_name=None, datastore_id=None, workflow_id=None,
                  workflow_instance_id=None, workflow_action_id=None, first_in_workflow=False, last_in_workflow=False,
                  ecs_task_arn=None, batch_job_id=None, extra_data=None, tags=None, user_id='anonymous',

--- a/src/python/dart/schema/action.py
+++ b/src/python/dart/schema/action.py
@@ -23,7 +23,7 @@ def action_schema(supported_action_type_params_schema):
             'on_failure': {
                 'type': 'string',
                 'enum': OnFailure.all(),
-                'default': OnFailure.DEACTIVATE,
+                'default': OnFailure.HALT,
                 'description': 'applies to the workflow if this is a workflow action template, otherwise the datastore'
             },
             'on_failure_email': email_list_schema(),

--- a/src/python/dart/web/api/action.py
+++ b/src/python/dart/web/api/action.py
@@ -158,7 +158,9 @@ def update_action_state():
                     master_workflow = workflow_service().get_workflow(workflow_id)
 
                     # Failed action with deactivate on_failure should deactivate the current workflow.
-                    if current_action.data.on_failure == ActionOnFailure.DEACTIVATE:
+                    if current_action.data.on_failure == ActionOnFailure.HALT:
+                        _logger.info("AWS_Batch: Action in workflow={0} failed. Halting on failure and remaining in state {2}".format(master_workflow.id, WorkflowState.ACTIVE))
+                    elif current_action.data.on_failure == ActionOnFailure.DEACTIVATE:
                         _logger.info("AWS_Batch: Updating workflow={0} to state {2}".format(master_workflow.id, WorkflowState.INACTIVE))
                         workflow_service().update_workflow_state(master_workflow, WorkflowState.INACTIVE)
                         if master_workflow.data.on_failure == WorkflowOnFailure.DEACTIVATE:


### PR DESCRIPTION
… stops the workflow execution (unless more retries are listed) without disabling the workflow.  This is important for the MasterMind migration workflows.